### PR TITLE
[DPE-7806] Rock derived from slim Opensearch Dashboards Snap

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,9 +69,9 @@ jobs:
          # opensearch rock
          version="$(yq .version rockcraft.yaml)"
          base="$(yq .base rockcraft.yaml)"
-         opensearch_img="ghcr.io/canonical/charmed-opensearch:${version}-${base#*@}_edge"
+         opensearch_img="ghcr.io/canonical/opensearch:${version}-${base#*@}_edge"
          docker pull ${opensearch_img}
-         docker tag ${opensearch_img} charmed-opensearch:${version}
+         docker tag ${opensearch_img} opensearch:${version}
 
      - name: Create local image
        run: |
@@ -91,7 +91,7 @@ jobs:
            --name cm0 \
            -e NODE_NAME=cm0 \
            -e INITIAL_CM_NODES=cm0 \
-            charmed-opensearch:"${version}"
+            opensearch:"${version}"
          )
          opensearch_cont_ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' "${opensearch_cont}")
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ env:
 on:
   push:
     branches:
-      - 2-24.04/edge
+      - 3-24.04
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -4,7 +4,7 @@ name: Trivy Security Scanner
 on:
   push:
     branches:
-      - 2-24.04/edge
+      - 3-24.04
   pull_request:
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ opensearch_cont_ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' "${ope
 
 docker run -d --rm \
     -p 127.0.0.1:5601:5601 \
-    -e OPENSEARCH_HOSTS='["http://${opensearch_cont_ip}:9200"]' \
+    -e OPENSEARCH_HOSTS='["http://'${opensearch_cont_ip}':9200"]' \
     opensearch-dashboards:${version}
 ```
 OpenSearch Dashboards will now be accessible at http://localhost:5601.

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -4,7 +4,7 @@ name: opensearch-dashboards
 base: ubuntu@24.04 # the base environment for this rock
 license: Apache-2.0
 
-version: '2.19.2' # just for humans. Semantic versioning is recommended
+version: '3.1.0' # just for humans. Semantic versioning is recommended
 
 summary: 'OpenSearch Dashboards: community-driven OpenSearch visualization suite.'
 description: |
@@ -36,7 +36,7 @@ parts:
     opensearch-dashboards-snap:
       plugin: nil
       stage-snaps:
-        - opensearch-dashboards/2/edge
+        - opensearch-dashboards/3/edge/dpe-7804
       stage:
         - "-opt/opensearch-dashboards/helpers"
         - "-opt/opensearch-dashboards/start.sh"

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -36,7 +36,7 @@ parts:
     opensearch-dashboards-snap:
       plugin: nil
       stage-snaps:
-        - opensearch-dashboards/3/edge/dpe-7804
+        - opensearch-dashboards/3/edge
       stage:
         - "-opt/opensearch-dashboards/helpers"
         - "-opt/opensearch-dashboards/start.sh"


### PR DESCRIPTION
This PR:
- Bumps the version to 3.1.0
- Updates the release and trivy workflow trigger branches
- Fixes README instructions

Addresses [DPE-7806]

[DPE-7806]: https://warthogs.atlassian.net/browse/DPE-7806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ