### PR TITLE
Improve readability of docker run commands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,7 @@ jobs:
          docker run -d --rm \
              --name dashboards \
              -p 127.0.0.1:5601:5601 \
-             -e OPENSEARCH_HOSTS='["http://'"${opensearch_cont_ip}"':9200"]' \
+             -e OPENSEARCH_HOSTS="[http://${opensearch_cont_ip}:9200]" \
              opensearch-dashboards:"${version}"
          
          sleep 10s

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ sudo rockcraft.skopeo --insecure-policy \
 docker run \
   -d --rm \
   -p 127.0.0.1:5601:5601 \
-  -e OPENSEARCH_HOSTS='["<your-opensearch-host>:<port>"]' \
+  -e OPENSEARCH_HOSTS="[http://<your-opensearch-host>:<port>]" \
   opensearch-dashboards:${version}
 ```
 ### Example alongside containerized OpenSearch
@@ -59,7 +59,7 @@ opensearch_cont_ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' "${ope
 
 docker run -d --rm \
     -p 127.0.0.1:5601:5601 \
-    -e OPENSEARCH_HOSTS='["http://${opensearch_cont_ip}:9200"]' \
+    -e OPENSEARCH_HOSTS="[http://${opensearch_cont_ip}:9200]" \
     opensearch-dashboards:${version}
 ```
 OpenSearch Dashboards will now be accessible at http://localhost:5601.


### PR DESCRIPTION
The mixing of double and single quotes when passing the `OPENSEARCH_HOSTS` env var is unnecessary and difficult to read.

This PR changes the commands in the README and CI test to use only double quotes.