### PR TITLE
Fix release tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
           version="$(yq .version rockcraft.yaml)"
           base=$(yq .base rockcraft.yaml)
           base="${base#*@}"
-          tag=${version}-${base}-${{ env.RELEASE }}
+          tag=${version}-${base}_${{ env.RELEASE }}
 
           echo "Publishing opensearch-dashboards:${tag}"
           sudo rockcraft.skopeo --insecure-policy copy \


### PR DESCRIPTION
This PR changes the release tag in `3-24.04` to use an underscore before env.RELEASE